### PR TITLE
Add support for Laravel 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,15 @@
     },
     "require": {
         "php": "~7.0",
-        "illuminate/http": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
-        "illuminate/routing":  "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
-        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
-        "illuminate/container": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
+        "illuminate/http": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0",
+        "illuminate/routing":  "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0",
+        "illuminate/container": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0",
         "spatie/array-to-xml": "^2.6"
     },
     "require-dev": {
-      "phpunit/phpunit": "^6.4",
-      "laravel/framework": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0"
+      "phpunit/phpunit": "^6.4|^8.5",
+      "laravel/framework": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/ResponseXmlTest.php
+++ b/tests/ResponseXmlTest.php
@@ -17,7 +17,7 @@ class ResponseXml extends TestCase
     /** @test string */
     protected $testXml;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->createDummyprovider()->register();
 


### PR DESCRIPTION
This PR adds support for Laravel 7.x and change the `setUp` mehod return type to void, because it must be compatible with `PHPUnit\Framework\TestCase` setUp method.