### PR TITLE
ResponseXmlTest rename the create dummy provider method

### DIFF
--- a/tests/ResponseXmlTest.php
+++ b/tests/ResponseXmlTest.php
@@ -22,7 +22,7 @@ class ResponseXml extends TestCase
 
     public function setUp() : void
     {
-        $this->createDummyprovider()->register();
+        $this->createDummyProvider()->register();
 
         $this->testArray = [
             'carrier' => 'fedex',
@@ -70,7 +70,7 @@ class ResponseXml extends TestCase
      * Bootstrap the provider
      *
      */
-    protected function createDummyprovider(): ResponseXmlServiceProvider
+    protected function createDummyProvider(): ResponseXmlServiceProvider
     {
         $reflectionClass = new Reflect(ResponseXmlServiceProvider::class);
         return $reflectionClass->newInstanceWithoutConstructor();


### PR DESCRIPTION
Hello,

I would like to propose a little improvement to the function naming. It increases consistency.